### PR TITLE
Fix for mix run --no-halt.

### DIFF
--- a/src/config/prod.exs
+++ b/src/config/prod.exs
@@ -64,7 +64,8 @@ config :logger, level: :info
 # import_config "prod.secret.exs"
 
 config :yelp, YelpWeb.Endpoint,
-  secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE")
+  secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE"),
+  server: true
 
 config :yelp, Yelp.Repo,
   adapter: Ecto.Adapters.Postgres,


### PR DESCRIPTION
I noticed that you have a Procfile, which gigalixir will use if it sees one, and it uses` mix run --no-halt`. The only difference between `mix run --no-halt` and `mix phx.server` is the latter sets `server: true` for you. So if you use the former, you have to set `server: true` yourself somehow. 

I tested this locally using `DATABASE_URL="postgres://foo:secret@localhost:5432/foo" PORT=4000 SECRET_KEY_BASE=$(mix phx.gen.secret) MIX_ENV=prod mix run --no-halt`

I haven't tested it on gigalixir yet, but I'm fairly sure this is the issue.